### PR TITLE
Update publication info graph with publication date using PubMed Id

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>nl.unimaas.bigcat.wikipathways.nanopubs</groupId>
+  <artifactId>wikipathways.nanopubs</artifactId>
+  <version>1-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer />
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration />
+      </plugin>
+    </plugins>
+  </build>
+  <repositories>
+    <repository>
+      <id>apache-repo-releases</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit.version>4.8.1</junit.version>
+  </properties>
+</project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
   </build>
 
   <dependencies>
+    <dependency>
+	    <groupId>com.googlecode.json-simple</groupId>
+	    <artifactId>json-simple</artifactId>
+	    <version>1.1.1</version>
+	</dependency>
   	<dependency>
   		<groupId>org.nanopub</groupId>
   		<artifactId>nanopub</artifactId>

--- a/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/ComplexesPubs.java
+++ b/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/ComplexesPubs.java
@@ -29,7 +29,7 @@ package nl.unimaas.bigcat.wikipathways.nanopubs;
 public class ComplexesPubs extends NanoPubs {
 
 	public static void main(String[] args) throws Exception {
-		createNanoPublications("complexes"); 
+		createNanoPublications("complexes");
 	}
 
 }

--- a/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/ComplexesPubs.java
+++ b/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/ComplexesPubs.java
@@ -29,7 +29,7 @@ package nl.unimaas.bigcat.wikipathways.nanopubs;
 public class ComplexesPubs extends NanoPubs {
 
 	public static void main(String[] args) throws Exception {
-		createNanoPublications("complexes");
+		createNanoPublications("complexes"); 
 	}
 
 }

--- a/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/NanoPubs.java
+++ b/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/NanoPubs.java
@@ -26,19 +26,25 @@
 */
 package nl.unimaas.bigcat.wikipathways.nanopubs;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.json.simple.parser.ParseException;
+
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
 import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubUtils;
 import org.nanopub.trusty.MakeTrustyNanopub;
 import org.openrdf.model.Resource;
 import org.openrdf.model.Statement;
 import org.openrdf.model.URI;
+import org.openrdf.model.ValueFactory;
 import org.openrdf.model.vocabulary.RDF;
 import org.openrdf.repository.RepositoryException;
 import org.openrdf.repository.RepositoryResult;
@@ -57,6 +63,7 @@ public class NanoPubs {
 		OPSWPRDFFiles.createNanopublications(data, "constructs/" + topic + ".insert");
 		SailRepositoryConnection conn = data.getConnection();
 		RepositoryResult<Resource> result = conn.getContextIDs();
+		
 		StringBuffer buffer = new StringBuffer();
 		int pubCount = 0;
 		while (result.hasNext()) {
@@ -92,8 +99,9 @@ public class NanoPubs {
 			namespaces.put("pmid", "http://identifiers.org/pubmed/");
 			namespaces.put("obo", "http://purl.obolibrary.org/obo/");
 			namespaces.put("pav", "http://purl.org/pav/>");
-			Nanopub nanopub = new NanopubImpl(data, (URI)nanopubId, prefixes, namespaces);
-			nanopub = MakeTrustyNanopub.transform(nanopub);
+			NanopubImpl nanopubImpl = new NanopubImpl(data, (URI)nanopubId, prefixes, namespaces);
+			Nanopub np = updateNanopublication(nanopubImpl, conn);
+			Nanopub nanopub = MakeTrustyNanopub.transform(np);
 			buffer.append(NanopubUtils.writeToString(nanopub, RDFFormat.TRIG)).append("\n\n");
 		}
 		conn.close();
@@ -103,5 +111,81 @@ public class NanoPubs {
 		}
 		ResourceHelper.saveToFile(topic + "." + subsetPrefix + ".trig", buffer.toString());
 		System.out.println("Number of saved nanopubs: " + pubCount);
+	}
+
+	private static Nanopub updateNanopublication(NanopubImpl nanopub, SailRepositoryConnection conn) {
+		NanopubCreator npCreator = new NanopubCreator();
+		npCreator.setNanopubUri(nanopub.getUri());
+		ValueFactory factory = conn.getValueFactory();
+		
+		// Add Namespaces
+		for(String prefix : nanopub.getNsPrefixes())
+		{
+			//System.out.println(prefix);
+			//System.out.println(np.getNamespace(prefix));
+			String namespace = nanopub.getNamespace(prefix);
+			npCreator.addNamespace(prefix, namespace);
+		}
+		npCreator.addNamespace("pav", "http://purl.org/pav/");
+		
+		//Add Assertion Statements
+		npCreator.setAssertionUri(nanopub.getAssertionUri());
+		for(Statement st : nanopub.getAssertion())
+		{
+			npCreator.addAssertionStatement(st.getSubject(), st.getPredicate(), st.getObject());
+		}
+		
+		//Add Provenance Statements
+		npCreator.setProvenanceUri(nanopub.getProvenanceUri());
+		Date pubDate = new Date();
+		
+		for(Statement st : nanopub.getProvenance())
+		{
+			if(st.getObject().stringValue().startsWith("http://identifiers.org/pubmed/"))
+			{
+				try {
+					pubDate = PubMed.getPublicationDate(st.getObject().stringValue().split("/pubmed/")[1]);
+				} catch (IOException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				} catch (ParseException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+			npCreator.addProvenanceStatement(st.getSubject(), st.getPredicate(), st.getObject());
+		}
+		
+		//Add PubInfo Statements
+		npCreator.setPubinfoUri(nanopub.getPubinfoUri());
+		Resource sub = null;
+		for(Statement st : nanopub.getPubinfo())
+		{
+			if(st.getSubject().equals(nanopub.getUri()))
+				sub = st.getSubject();
+			//sub = st.getSubject();
+			if(st.getPredicate().stringValue().equals("http://purl.org/dc/terms/created"))
+			{
+				npCreator.addPubinfoStatement(st.getSubject(), factory.createURI("http://purl.org/pav/","createdOn"), st.getObject());
+			}
+			else
+			{
+				npCreator.addPubinfoStatement(st.getSubject(), st.getPredicate(), st.getObject());
+			}	
+		}
+		
+		npCreator.addPubinfoStatement(sub, factory.createURI("http://purl.org/pav/","authoredOn"), factory.createLiteral(pubDate));
+		
+		///////////////////////////////////////////////////////////////
+		npCreator.setNanopubUri(nanopub.getUri());
+		
+		try {
+			return npCreator.finalizeNanopub();
+		} catch (MalformedNanopubException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		return null;
 	}
 }

--- a/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/PubMed.java
+++ b/src/main/java/nl/unimaas/bigcat/wikipathways/nanopubs/PubMed.java
@@ -1,0 +1,96 @@
+package nl.unimaas.bigcat.wikipathways.nanopubs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+public class PubMed {
+	   public static Date getPublicationDate(String pubmedId) throws IOException, ParseException {
+		   if(isNumeric(pubmedId))
+		   {
+			    String postUrl = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id="+pubmedId+"&retmode=json"; //post url
+			    //URLConnection conn = null;
+			    
+//	    		URL url = new URL(postUrl);
+//		        conn = url.openConnection();
+//		        conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36");
+		       
+			    URL url = new URL(postUrl);
+			    HttpURLConnection conn = (HttpURLConnection)url.openConnection(); 
+			    conn.setRequestMethod("GET");
+			    conn.connect();
+			    int responsecode = conn.getResponseCode();
+			    if(responsecode != 200)
+			    {
+			    	System.out.println(pubmedId);
+			    	throw new RuntimeException("HttpResponseCode: " +responsecode);
+			    }
+			    else
+			    {
+			    	InputStreamReader inputStreamReader = new InputStreamReader(conn.getInputStream());
+			    	BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+			    	JSONParser parse = new JSONParser();
+			    	JSONObject jobj = (JSONObject)parse.parse(bufferedReader);
+			    	JSONObject resultJson = (JSONObject) jobj.get("result");
+			    	JSONObject pubmedJson = (JSONObject) resultJson.get(pubmedId);
+			    	String jsonDate = "";
+			    	
+			    	conn.disconnect();
+			    	
+			    	if (!((String)pubmedJson.get("epubdate")).equals(""))
+			    		jsonDate = (String)pubmedJson.get("epubdate");
+			    	else if(!((String)pubmedJson.get("pubdate")).equals(""))
+			    		jsonDate = (String)pubmedJson.get("pubdate");
+			    		
+			    	String[] splitDate = jsonDate.split("-");
+			    	String date = "";
+			    	if(splitDate[0].split(" ").length == 3)
+			    		date = splitDate[0];
+			    	else if(splitDate[0].split(" ").length == 2)
+			    		date = splitDate[0] + " 01";
+			    	else
+			    		date = splitDate[0] + " Jan 01";
+			    	
+			    	SimpleDateFormat format = new SimpleDateFormat("yyyy MMM dd");
+			    	String dateString = format.format( new Date());
+			    	//System.out.println(dateString);
+			    	try {
+						Date pubDate = format.parse ( date );
+						format = new SimpleDateFormat("yyyy-MM-dd");
+						
+						return pubDate;
+					} catch (java.text.ParseException e) {
+						System.out.println(pubmedId + " " + jsonDate);
+						System.out.println(e);
+					} 
+			    }		   
+		   }
+
+			return null;
+		}
+	   
+	   public static boolean isNumeric(final String str) {
+
+	       if (str == null || str.length() == 0) {
+	           return false;
+	       }
+
+	       try {
+
+	           Integer.parseInt(str);
+	           return true;
+
+	       } catch (NumberFormatException e) {
+	           return false;
+	       }
+
+	   }
+}


### PR DESCRIPTION
The reason for this Pull request is that to find the timeline of discourse. I updated the code that fetched the PubMed ID's publication date using the PubMed API (In PubMed Java class). After fetching the publication date, I put it in the publication information graph with pav:authoredOn predicate. I also updated the dcterms:created to pav:createdOn because pav:createdOn is the date of creating the digital artefact or resource representation.